### PR TITLE
Add Additional Provisioning States

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ helm upgrade --install aks-state-exporter oci://ghcr.io/ricoberger/charts/aks-st
 ## Metrics
 
 ```txt
-# HELP aks_cluster_provisioning_state The provisioning state of the cluster (0 - Unknown, 1 - Succeeded, 2 - Failed, 3 - Canceled, 4 - Creating, 5 - Updating, 6 - Deleting)
+# HELP aks_cluster_provisioning_state The provisioning state of the cluster (0 - Unknown, 1 - Succeeded, 2 - Failed, 3 - Canceled, 4 - Creating, 5 - Updating, 6 - Deleting, 7 - Upgrading, 8 - UpgradingNodeImageVersion, 9 - ReconcilingClusterETCDCertificates)
 # TYPE aks_cluster_provisioning_state gauge
 aks_cluster_provisioning_state{name="dev-de1",resource_group="dev-de1"} 1
 aks_cluster_provisioning_state{name="prod-de1",resource_group="prod-de1"} 1
 aks_cluster_provisioning_state{name="stage-de1",resource_group="stage-de1"} 1
-# HELP aks_nodepool_provisioning_state The provisioning state of the node pool (0 - Unknown, 1 - Succeeded, 2 - Failed, 3 - Canceled, 4 - Creating, 5 - Updating, 6 - Deleting)
+# HELP aks_nodepool_provisioning_state The provisioning state of the node pool (0 - Unknown, 1 - Succeeded, 2 - Failed, 3 - Canceled, 4 - Creating, 5 - Updating, 6 - Deleting, 7 - Upgrading, 8 - UpgradingNodeImageVersion, 9 - ReconcilingClusterETCDCertificates)
 # TYPE aks_nodepool_provisioning_state gauge
 aks_nodepool_provisioning_state{cluster="dev-de1",name="system",resource_group="dev-de1"} 1
 aks_nodepool_provisioning_state{cluster="dev-de1",name="zone1",resource_group="dev-de1"} 1

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -31,8 +31,8 @@ func New(config Config) (*Exporter, error) {
 
 	return &Exporter{
 		aksClient:                 aksClient,
-		ClusterProvisioningState:  prometheus.NewDesc("aks_cluster_provisioning_state", "The provisioning state of the cluster (0 - Unknown, 1 - Succeeded, 2 - Failed, 3 - Canceled, 4 - Creating, 5 - Updating, 6 - Deleting)", []string{"name", "resource_group"}, nil),
-		NodePoolProvisioningState: prometheus.NewDesc("aks_nodepool_provisioning_state", "The provisioning state of the node pool (0 - Unknown, 1 - Succeeded, 2 - Failed, 3 - Canceled, 4 - Creating, 5 - Updating, 6 - Deleting)", []string{"name", "cluster", "resource_group"}, nil),
+		ClusterProvisioningState:  prometheus.NewDesc("aks_cluster_provisioning_state", "The provisioning state of the cluster (0 - Unknown, 1 - Succeeded, 2 - Failed, 3 - Canceled, 4 - Creating, 5 - Updating, 6 - Deleting, 7 - Upgrading, 8 - UpgradingNodeImageVersion, 9 - ReconcilingClusterETCDCertificates)", []string{"name", "resource_group"}, nil),
+		NodePoolProvisioningState: prometheus.NewDesc("aks_nodepool_provisioning_state", "The provisioning state of the node pool (0 - Unknown, 1 - Succeeded, 2 - Failed, 3 - Canceled, 4 - Creating, 5 - Updating, 6 - Deleting, 7 - Upgrading, 8 - UpgradingNodeImageVersion, 9 - ReconcilingClusterETCDCertificates)", []string{"name", "cluster", "resource_group"}, nil),
 	}, nil
 }
 
@@ -96,6 +96,12 @@ func provisioningStateToFloat64(state string) float64 {
 		return 5
 	case "Deleting":
 		return 6
+	case "Upgrading":
+		return 7
+	case "UpgradingNodeImageVersion":
+		return 8
+	case "ReconcilingClusterETCDCertificates":
+		return 9
 	default:
 		return 0
 	}


### PR DESCRIPTION
This commit adds additional provisioning states, which where exported as
`0 - Unknown` until now. The additional provisioning states are:

- `7 - Upgrading`
- `8 - UpgradingNodeImageVersion`
- `9 - ReconcilingClusterETCDCertificates`
