### PR TITLE
feat: add new node pool metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ helm upgrade --install aks-state-exporter oci://ghcr.io/ricoberger/charts/aks-st
 aks_cluster_provisioning_state{name="dev-de1",resource_group="dev-de1"} 1
 aks_cluster_provisioning_state{name="prod-de1",resource_group="prod-de1"} 1
 aks_cluster_provisioning_state{name="stage-de1",resource_group="stage-de1"} 1
+
 # HELP aks_nodepool_provisioning_state The provisioning state of the node pool (0 - Unknown, 1 - Succeeded, 2 - Failed, 3 - Canceled, 4 - Creating, 5 - Updating, 6 - Deleting, 7 - Upgrading, 8 - UpgradingNodeImageVersion, 9 - ReconcilingClusterETCDCertificates)
 # TYPE aks_nodepool_provisioning_state gauge
 aks_nodepool_provisioning_state{cluster="dev-de1",name="system",resource_group="dev-de1"} 1
@@ -51,4 +52,19 @@ aks_nodepool_provisioning_state{cluster="stage-de1",name="system",resource_group
 aks_nodepool_provisioning_state{cluster="stage-de1",name="zone1",resource_group="stage-de1"} 1
 aks_nodepool_provisioning_state{cluster="stage-de1",name="zone2",resource_group="stage-de1"} 1
 aks_nodepool_provisioning_state{cluster="stage-de1",name="zone3",resource_group="stage-de1"} 1
+
+# HELP aks_nodepool_count The number of nodes in the node pool
+# TYPE aks_nodepool_count gauge
+aks_nodepool_count{cluster="dev-de1",name="system",resource_group="dev-de1"} 3
+aks_nodepool_count{cluster="dev-de1",name="zone1",resource_group="dev-de1"} 1
+
+# HELP aks_nodepool_max_count The maximum number of nodes in the node pool
+# TYPE aks_nodepool_max_count gauge
+aks_nodepool_max_count{cluster="dev-de1",name="system",resource_group="dev-de1"} 0
+aks_nodepool_max_count{cluster="dev-de1",name="zone1",resource_group="dev-de1"} 8
+
+# HELP aks_nodepool_min_count The minimum number of nodes in the node pool
+# TYPE aks_nodepool_min_count gauge
+aks_nodepool_min_count{cluster="dev-de1",name="system",resource_group="dev-de1"} 0
+aks_nodepool_min_count{cluster="dev-de1",name="zone1",resource_group="dev-de1"} 1
 ```

--- a/pkg/exporter/aks/aks.go
+++ b/pkg/exporter/aks/aks.go
@@ -33,6 +33,9 @@ type NodePool struct {
 	Cluster           string
 	ResourceGroup     string
 	ProvisioningState string
+	Count             int32
+	MinCount          int32
+	MaxCount          int32
 }
 
 type Client interface {
@@ -84,12 +87,37 @@ func (c *client) GetNodePools(ctx context.Context, clusterName string, resourceG
 		}
 
 		for _, nodePool := range page.Value {
-			nodePools = append(nodePools, NodePool{
-				Name:              *nodePool.Name,
-				Cluster:           clusterName,
-				ResourceGroup:     resourceGroup,
-				ProvisioningState: *nodePool.Properties.ProvisioningState,
-			})
+			if nodePool != nil && nodePool.Properties != nil && nodePool.Name != nil {
+				provisioningState := ""
+				if nodePool.Properties.ProvisioningState != nil {
+					provisioningState = *nodePool.Properties.ProvisioningState
+				}
+
+				count := int32(0)
+				if nodePool.Properties.Count != nil {
+					count = *nodePool.Properties.Count
+				}
+
+				minCount := int32(0)
+				if nodePool.Properties.MinCount != nil {
+					minCount = *nodePool.Properties.MinCount
+				}
+
+				maxCount := int32(0)
+				if nodePool.Properties.MaxCount != nil {
+					maxCount = *nodePool.Properties.MaxCount
+				}
+
+				nodePools = append(nodePools, NodePool{
+					Name:              *nodePool.Name,
+					Cluster:           clusterName,
+					ResourceGroup:     resourceGroup,
+					ProvisioningState: provisioningState,
+					Count:             count,
+					MinCount:          minCount,
+					MaxCount:          maxCount,
+				})
+			}
 		}
 	}
 

--- a/pkg/exporter/exporter.go
+++ b/pkg/exporter/exporter.go
@@ -19,6 +19,9 @@ type Exporter struct {
 	aksClient                 aks.Client
 	ClusterProvisioningState  *prometheus.Desc
 	NodePoolProvisioningState *prometheus.Desc
+	NodePoolCount             *prometheus.Desc
+	NodePoolMinCount          *prometheus.Desc
+	NodePoolMaxCount          *prometheus.Desc
 }
 
 // New returns a new `Exporter` which can be passed to the
@@ -33,6 +36,9 @@ func New(config Config) (*Exporter, error) {
 		aksClient:                 aksClient,
 		ClusterProvisioningState:  prometheus.NewDesc("aks_cluster_provisioning_state", "The provisioning state of the cluster (0 - Unknown, 1 - Succeeded, 2 - Failed, 3 - Canceled, 4 - Creating, 5 - Updating, 6 - Deleting, 7 - Upgrading, 8 - UpgradingNodeImageVersion, 9 - ReconcilingClusterETCDCertificates)", []string{"name", "resource_group"}, nil),
 		NodePoolProvisioningState: prometheus.NewDesc("aks_nodepool_provisioning_state", "The provisioning state of the node pool (0 - Unknown, 1 - Succeeded, 2 - Failed, 3 - Canceled, 4 - Creating, 5 - Updating, 6 - Deleting, 7 - Upgrading, 8 - UpgradingNodeImageVersion, 9 - ReconcilingClusterETCDCertificates)", []string{"name", "cluster", "resource_group"}, nil),
+		NodePoolCount:             prometheus.NewDesc("aks_nodepool_count", "The number of nodes in the node pool", []string{"name", "cluster", "resource_group"}, nil),
+		NodePoolMinCount:          prometheus.NewDesc("aks_nodepool_min_count", "The minimum number of nodes in the node pool", []string{"name", "cluster", "resource_group"}, nil),
+		NodePoolMaxCount:          prometheus.NewDesc("aks_nodepool_max_count", "The maximum number of nodes in the node pool", []string{"name", "cluster", "resource_group"}, nil),
 	}, nil
 }
 
@@ -76,8 +82,11 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 		slog.Debug("Collecting metrics for node pools", slog.String("cluster", cluster.Name), slog.String("resource_group", cluster.ResourceGroup), slog.Int("count", len(nodePools)))
 
 		for _, nodePool := range nodePools {
-			slog.Debug("Collecting metrics for node pool", slog.String("name", nodePool.Name), slog.String("cluster", nodePool.Cluster), slog.String("resource_group", nodePool.ResourceGroup), slog.String("provisioning_state", nodePool.ProvisioningState))
+			slog.Debug("Collecting metrics for node pool", slog.String("name", nodePool.Name), slog.String("cluster", nodePool.Cluster), slog.String("resource_group", nodePool.ResourceGroup), slog.String("provisioning_state", nodePool.ProvisioningState), slog.Int("count", int(nodePool.Count)), slog.Int("min_count", int(nodePool.MinCount)), slog.Int("max_count", int(nodePool.MaxCount)))
 			ch <- prometheus.MustNewConstMetric(e.NodePoolProvisioningState, prometheus.GaugeValue, provisioningStateToFloat64(nodePool.ProvisioningState), nodePool.Name, nodePool.Cluster, nodePool.ResourceGroup)
+			ch <- prometheus.MustNewConstMetric(e.NodePoolCount, prometheus.GaugeValue, float64(nodePool.Count), nodePool.Name, nodePool.Cluster, nodePool.ResourceGroup)
+			ch <- prometheus.MustNewConstMetric(e.NodePoolMinCount, prometheus.GaugeValue, float64(nodePool.MinCount), nodePool.Name, nodePool.Cluster, nodePool.ResourceGroup)
+			ch <- prometheus.MustNewConstMetric(e.NodePoolMaxCount, prometheus.GaugeValue, float64(nodePool.MaxCount), nodePool.Name, nodePool.Cluster, nodePool.ResourceGroup)
 		}
 	}
 }


### PR DESCRIPTION
Add new node pool metrics to monitor the node count and the min / max
node count for each node pool:

- `aks_nodepool_count`: The number of nodes in the node pool
- `aks_nodepool_max_count`: The maximum number of nodes in the node pool
- `aks_nodepool_min_count`: The minimum number of nodes in the node pool
